### PR TITLE
Feature/spacio 97/get owner environments view

### DIFF
--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -59,8 +59,6 @@ const EnvironmentsPage = () => {
             : 0,
         };
 
-        console.log(requestBody);
-
         const res = await fetch(
           `http://localhost:5150/api/environments/available?page=${page}&limit=${limit}`,
           {

--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -1,19 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  Box,
-  Button,
-  Container,
-  Grid,
-  Skeleton,
-  Typography,
-  Pagination,
-} from "@mui/material";
-import EnvironmentCard from "@/components/card/EnvironmentCard";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Environment } from "@/types/AllEnvironments";
 import { PageRoutes } from "@/utils/constants/page-routes";
+import EnvironmentGrid from "@/components/grid/EnvironmentGrid";
 
 const EnvironmentsPage = () => {
   const [environments, setEnvironments] = useState<Environment[]>([]);
@@ -45,12 +36,12 @@ const EnvironmentsPage = () => {
           environmentTypePublicKey: searchParams.get("type") || undefined,
           startDate: searchParams.get("startDate")
             ? Math.floor(
-                new Date(searchParams.get("startDate")!).getTime() / 1000,
+                new Date(searchParams.get("startDate")!).getTime() / 1000
               )
             : undefined,
           endDate: searchParams.get("endDate")
             ? Math.floor(
-                new Date(searchParams.get("endDate")!).getTime() / 1000,
+                new Date(searchParams.get("endDate")!).getTime() / 1000
               )
             : undefined,
           servicePublicKeys: services,
@@ -78,7 +69,7 @@ const EnvironmentsPage = () => {
               "Content-Type": "application/json",
             },
             body: JSON.stringify(requestBody),
-          },
+          }
         );
 
         const data = await res.json();
@@ -94,53 +85,21 @@ const EnvironmentsPage = () => {
     fetchEnvironments();
   }, [searchParams, page]);
 
-  const handlePageChange = (_: React.ChangeEvent<unknown>, value: number) => {
+  const handlePageChange = (value: number) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set("page", value.toString());
     router.push(`/${PageRoutes.Search}?${params.toString()}`);
   };
 
   return (
-    <Container maxWidth={false} sx={{ py: 4 }}>
-      {loading ? (
-        <Grid container spacing={2} sx={{ width: "100%" }}>
-          {Array.from(new Array(16)).map((_, index) => (
-            <Grid key={index} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-              <Skeleton variant="rectangular" height={300} />
-            </Grid>
-          ))}
-        </Grid>
-      ) : environments.length === 0 ? (
-        <Box textAlign="center" mt={10}>
-          <Typography variant="h6" gutterBottom>
-            No hay Ambientes que coincidan con tu criterio de búsqueda
-          </Typography>
-          <Button variant="contained" onClick={() => router.back()}>
-            Volver atrás
-          </Button>
-        </Box>
-      ) : (
-        <>
-          <Grid container spacing={2} sx={{ width: "100%" }}>
-            {environments.map((env) => (
-              <Grid key={env.publicId} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
-                <EnvironmentCard environment={env} />
-              </Grid>
-            ))}
-          </Grid>
-          {totalPages > 1 && (
-            <Box mt={4} display="flex" justifyContent="center">
-              <Pagination
-                count={totalPages}
-                page={page}
-                onChange={handlePageChange}
-                color="primary"
-              />
-            </Box>
-          )}
-        </>
-      )}
-    </Container>
+    <EnvironmentGrid
+      environments={environments}
+      loading={loading}
+      totalPages={totalPages}
+      page={page}
+      onPageChange={handlePageChange}
+      emptyMessage="No hay Ambientes que coincidan con tu criterio de búsqueda"
+    />
   );
 };
 

--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -36,12 +36,12 @@ const EnvironmentsPage = () => {
           environmentTypePublicKey: searchParams.get("type") || undefined,
           startDate: searchParams.get("startDate")
             ? Math.floor(
-                new Date(searchParams.get("startDate")!).getTime() / 1000
+                new Date(searchParams.get("startDate")!).getTime() / 1000,
               )
             : undefined,
           endDate: searchParams.get("endDate")
             ? Math.floor(
-                new Date(searchParams.get("endDate")!).getTime() / 1000
+                new Date(searchParams.get("endDate")!).getTime() / 1000,
               )
             : undefined,
           servicePublicKeys: services,
@@ -69,7 +69,7 @@ const EnvironmentsPage = () => {
               "Content-Type": "application/json",
             },
             body: JSON.stringify(requestBody),
-          }
+          },
         );
 
         const data = await res.json();

--- a/src/app/mis-ambientes/page.tsx
+++ b/src/app/mis-ambientes/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Box } from "@mui/material";

--- a/src/app/mis-ambientes/page.tsx
+++ b/src/app/mis-ambientes/page.tsx
@@ -1,23 +1,72 @@
 "use client";
-import React from "react";
-import { useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Box, Container } from "@mui/material";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import ResponsiveFab from "@/components/buttons/ResponsiveFabButton";
+import { Environment } from "@/types/AllEnvironments";
+import EnvironmentGrid from "@/components/grid/EnvironmentGrid";
 
 const EnvironmentsPage = () => {
   const router = useRouter();
+  const [environments, setEnvironments] = useState<Environment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [totalPages, setTotalPages] = useState(1);
 
-  const handleClick = () => {
+  const searchParams = useSearchParams();
+
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const limit = 16;
+
+  useEffect(() => {
+    const fetchOwnerEnvironments = async () => {
+      try {
+        const res = await fetch(
+          "http://localhost:5150/api/environments/owner?page=1&limit=10",
+          {
+            method: "GET",
+            credentials: "include", 
+          }
+        );
+
+        const data = await res.json();
+        setEnvironments(data.items || []);
+        setTotalPages(data.totalPages || 1);
+      } catch {
+        alert("Error cargando tus ambientes");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOwnerEnvironments();
+  }, [page, searchParams]);
+
+  const handleFabAdd = () => {
     router.push(PageRoutes.New_Environment);
   };
 
+  const handlePageChange = (value: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", value.toString());
+    router.push(`/${PageRoutes.Owner_Single_Environment}?${params.toString()}`);
+  };
+
   return (
-    <Container maxWidth={false} sx={{ py: 4 }}>
+    <Box>
       <Box sx={{ p: 3 }}></Box>
 
-      <ResponsiveFab onClick={handleClick} />
-    </Container>
+      <EnvironmentGrid
+        environments={environments}
+        loading={loading}
+        totalPages={totalPages}
+        page={page}
+        onPageChange={handlePageChange}
+        emptyMessage="Aún no has creado ningún ambiente"
+      />
+
+      <ResponsiveFab onClick={handleFabAdd} />
+    </Box>
   );
 };
 

--- a/src/app/mis-ambientes/page.tsx
+++ b/src/app/mis-ambientes/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Box, Container } from "@mui/material";
+import { Box } from "@mui/material";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import ResponsiveFab from "@/components/buttons/ResponsiveFabButton";
 import { Environment } from "@/types/AllEnvironments";
@@ -22,7 +22,7 @@ const EnvironmentsPage = () => {
     const fetchOwnerEnvironments = async () => {
       try {
         const res = await fetch(
-          "http://localhost:5150/api/environments/owner?page=1&limit=10",
+          `http://localhost:5150/api/environments/owner?page=${page}&limit=${limit}`,
           {
             method: "GET",
             credentials: "include",

--- a/src/app/mis-ambientes/page.tsx
+++ b/src/app/mis-ambientes/page.tsx
@@ -25,8 +25,8 @@ const EnvironmentsPage = () => {
           "http://localhost:5150/api/environments/owner?page=1&limit=10",
           {
             method: "GET",
-            credentials: "include", 
-          }
+            credentials: "include",
+          },
         );
 
         const data = await res.json();

--- a/src/components/grid/EnvironmentGrid.tsx
+++ b/src/components/grid/EnvironmentGrid.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  Box,
+  Button,
+  Container,
+  Grid,
+  Skeleton,
+  Typography,
+  Pagination,
+} from "@mui/material";
+import EnvironmentCard from "@/components/card/EnvironmentCard";
+import { useRouter } from "next/navigation";
+import { Environment } from "@/types/AllEnvironments";
+
+type Props = {
+  environments: Environment[];
+  loading: boolean;
+  totalPages: number;
+  page: number;
+  onPageChange: (value: number) => void;
+  emptyMessage?: string;
+};
+
+const EnvironmentGrid = ({
+  environments,
+  loading,
+  totalPages,
+  page,
+  onPageChange,
+  emptyMessage = "No hay ambientes disponibles",
+}: Props) => {
+  const router = useRouter();
+
+  return (
+    <Container maxWidth={false} sx={{ py: 4 }}>
+      {loading ? (
+        <Grid container spacing={2}>
+          {Array.from(new Array(16)).map((_, index) => (
+            <Grid key={index} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+              <Skeleton variant="rectangular" height={300} />
+            </Grid>
+          ))}
+        </Grid>
+      ) : environments.length === 0 ? (
+        <Box textAlign="center" mt={10}>
+          <Typography variant="h6" gutterBottom>
+            {emptyMessage}
+          </Typography>
+          <Button variant="contained" onClick={() => router.back()}>
+            Volver atrás
+          </Button>
+        </Box>
+      ) : (
+        <>
+          <Grid container spacing={2}>
+            {environments.map((env) => (
+              <Grid key={env.publicId} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                <EnvironmentCard environment={env} />
+              </Grid>
+            ))}
+          </Grid>
+          {totalPages > 1 && (
+            <Box mt={4} display="flex" justifyContent="center">
+              <Pagination
+                count={totalPages}
+                page={page}
+                onChange={(_, val) => onPageChange(val)}
+                color="primary"
+              />
+            </Box>
+          )}
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default EnvironmentGrid;

--- a/src/components/tour/VirtualTour.tsx
+++ b/src/components/tour/VirtualTour.tsx
@@ -22,8 +22,8 @@ const VirtualTour = ({ tour360Id }: VirtualTourProps) => {
         const json = await res.json();
         setTourData(json);
         setCurrentScene(json.scenes?.[0]);
-      } catch (error) {
-        console.error("Error fetching tour 360:", error);
+      } catch {
+        alert("No se pudo cargar el tour virtual, recarga la página por favor");
       }
     };
 

--- a/src/utils/constants/page-routes.ts
+++ b/src/utils/constants/page-routes.ts
@@ -2,6 +2,7 @@ export enum PageRoutes {
   Home = "/",
   Notifications = "/notificaciones",
   Owner_Environments = "/mis-ambientes",
+  Owner_Single_Environment = "/mi-ambiente",
   Booking = "/reservas",
   Profile = "/perfil",
   Shots_360 = "/capturas-360",


### PR DESCRIPTION
### What I did:
Added a new page for owners to view their environments with pagination and integrated it into the routing system.

---

### How I did it:

Created OwnerEnvironmentsPage to fetch and display environments from the /api/environments/owner endpoint.

Reused the existing EnvironmentCard and built a new reusable EnvironmentGrid component to avoid code duplication.

Implemented loading state, empty state, and pagination logic using searchParams and Pagination from MUI.

---

### Why I did it:
To provide owners with a clear and interactive way to manage and review the environments they have created.