### PR TITLE
Feature/spacio 61/admin get tour 360 requests

### DIFF
--- a/src/app/capturas360/page.tsx
+++ b/src/app/capturas360/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Container, Typography } from "@mui/material";
+import { useRouter, useSearchParams } from "next/navigation";
+import Tour360Filter from "@/components/inputs/select/Tour360Filter";
+import Tour360RequestsGrid from "@/components/grid/Tour360RequestGrid";
+
+interface Tour360Request {
+  environmentId: string;
+  environmentName: string;
+  ownerId: string;
+  requestDate: number;
+  scheduledDate?: number;
+  status: string;
+  technicianName?: string;
+  notes?: string;
+}
+
+const Tour360RequestsPage = () => {
+  const [requests, setRequests] = useState<Tour360Request[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const limit = 8;
+  const statusFilter = searchParams.get("status") || "";
+
+  useEffect(() => {
+    const fetchRequests = async () => {
+      setLoading(true);
+      try {
+        const url = new URL("http://localhost:5101/api/tour360requests");
+        url.searchParams.append("page", page.toString());
+        url.searchParams.append("limit", limit.toString());
+        if (statusFilter) {
+          url.searchParams.append("status", statusFilter);
+        }
+
+        const res = await fetch(url.toString());
+        const data = await res.json();
+        setRequests(data.items || []);
+        setTotalPages(data.totalPages || 1);
+      } catch {
+        alert("Error al cargar las solicitudes.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRequests();
+  }, [page, statusFilter]);
+
+  const handlePageChange = (value: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", value.toString());
+    router.push(`/tour360requests?${params.toString()}`);
+  };
+
+  const handleStatusChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set("status", value);
+    } else {
+      params.delete("status");
+    }
+    params.set("page", "1");
+    router.push(`/tour360requests?${params.toString()}`);
+  };
+
+  return (
+    <Container maxWidth={false} sx={{ py: 4 }}>
+      <Typography variant="h4" mb={4} mt={5}>
+        Solicitudes de Tour 360
+      </Typography>
+
+      <Box mb={4} display="flex" justifyContent="flex-end">
+        <Tour360Filter
+          statusFilter={statusFilter}
+          onStatusChange={handleStatusChange}
+        />
+      </Box>
+
+      <Tour360RequestsGrid
+        requests={requests}
+        loading={loading}
+        page={page}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+      />
+    </Container>
+  );
+};
+
+export default Tour360RequestsPage;

--- a/src/app/detalles/[publicId]/page.tsx
+++ b/src/app/detalles/[publicId]/page.tsx
@@ -27,7 +27,7 @@ export default function EnvironmentDetailsPage() {
     const fetchEnvironment = async () => {
       try {
         const res = await fetch(
-          `http://localhost:5150/api/environments/single?publicId=${publicId}`
+          `http://localhost:5150/api/environments/single?publicId=${publicId}`,
         );
         const result = await res.json();
         setData(result);

--- a/src/app/detalles/[publicId]/page.tsx
+++ b/src/app/detalles/[publicId]/page.tsx
@@ -27,12 +27,12 @@ export default function EnvironmentDetailsPage() {
     const fetchEnvironment = async () => {
       try {
         const res = await fetch(
-          `http://localhost:5150/api/environments/single?publicId=${publicId}`,
+          `http://localhost:5150/api/environments/single?publicId=${publicId}`
         );
         const result = await res.json();
         setData(result);
-      } catch (err) {
-        console.error("Error al cargar el ambiente", err);
+      } catch {
+        alert("Error al cargar el ambiente, intenta de nuevo.");
       } finally {
         setLoading(false);
       }

--- a/src/app/mis-ambientes/page.tsx
+++ b/src/app/mis-ambientes/page.tsx
@@ -27,7 +27,7 @@ const EnvironmentsPage = () => {
           {
             method: "GET",
             credentials: "include",
-          }
+          },
         );
 
         const data = await res.json();

--- a/src/app/mis-ambientes/page.tsx
+++ b/src/app/mis-ambientes/page.tsx
@@ -27,7 +27,7 @@ const EnvironmentsPage = () => {
           {
             method: "GET",
             credentials: "include",
-          },
+          }
         );
 
         const data = await res.json();
@@ -54,7 +54,7 @@ const EnvironmentsPage = () => {
   };
 
   return (
-    <Box>
+    <>
       <Box sx={{ p: 3 }}></Box>
 
       <EnvironmentGrid
@@ -67,7 +67,7 @@ const EnvironmentsPage = () => {
       />
 
       <ResponsiveFab onClick={handleFabAdd} />
-    </Box>
+    </>
   );
 };
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -17,7 +17,7 @@ const BottomNav: React.FC<BottomNavProps> = ({
   const [value, setValue] = useState(0);
   const navItems = getBottomNavItems(userType);
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"), {
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down("md"), {
     noSsr: true,
   });
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ import { UserType } from "@/utils/constants/user-constants";
 
 const Header: React.FC = () => {
   const theme = useTheme();
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up("sm"));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up("md"));
 
   const role = useSelector((state: RootState) => state.user.role);
   const userType: UserType =

--- a/src/components/card/Tour360RequestCard.tsx
+++ b/src/components/card/Tour360RequestCard.tsx
@@ -1,0 +1,59 @@
+import { Card, CardContent, Typography } from "@mui/material";
+
+type Props = {
+  environmentName: string;
+  status: string;
+  requestDate: number;
+  scheduledDate?: number;
+};
+
+const Tour360RequestCard = ({
+  environmentName,
+  status,
+  requestDate,
+  scheduledDate,
+}: Props) => {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          {environmentName}
+        </Typography>
+        <Typography variant="body2">
+          Estado: {translateStatus(status)}
+        </Typography>
+        <Typography variant="body2">
+          Fecha de solicitud: {formatDate(requestDate)}
+        </Typography>
+        {scheduledDate && (
+          <Typography variant="body2">
+            Fecha programada: {formatDate(scheduledDate)}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+// Helpers
+const translateStatus = (status: string) => {
+  switch (status) {
+    case "Pending":
+      return "Pendiente";
+    case "Scheduled":
+      return "Programado";
+    case "Completed":
+      return "Completado";
+    case "Cancelled":
+      return "Cancelado";
+    default:
+      return status;
+  }
+};
+
+const formatDate = (timestamp: number) => {
+  const date = new Date(timestamp * 1000);
+  return date.toLocaleDateString("es-ES");
+};
+
+export default Tour360RequestCard;

--- a/src/components/grid/EnvironmentGrid.tsx
+++ b/src/components/grid/EnvironmentGrid.tsx
@@ -33,9 +33,9 @@ const EnvironmentGrid = ({
   const router = useRouter();
 
   return (
-    <Container maxWidth={false} sx={{ py: 4 }}>
+    <Container maxWidth={false} sx={{ py: 4, width: "100%" }}>
       {loading ? (
-        <Grid container spacing={2}>
+        <Grid container spacing={2} sx={{ width: "100%" }}>
           {Array.from(new Array(16)).map((_, index) => (
             <Grid key={index} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
               <Skeleton variant="rectangular" height={300} />
@@ -52,8 +52,8 @@ const EnvironmentGrid = ({
           </Button>
         </Box>
       ) : (
-        <>
-          <Grid container spacing={2}>
+        <Box>
+          <Grid container spacing={2} sx={{ width: "100%" }}>
             {environments.map((env) => (
               <Grid key={env.publicId} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
                 <EnvironmentCard environment={env} />
@@ -70,7 +70,7 @@ const EnvironmentGrid = ({
               />
             </Box>
           )}
-        </>
+        </Box>
       )}
     </Container>
   );

--- a/src/components/grid/Tour360RequestGrid.tsx
+++ b/src/components/grid/Tour360RequestGrid.tsx
@@ -1,0 +1,83 @@
+import { Box, Grid, Pagination, Skeleton, Typography } from "@mui/material";
+import Tour360RequestCard from "../card/Tour360RequestCard";
+
+type Tour360Request = {
+  environmentId: string;
+  environmentName: string;
+  ownerId: string;
+  requestDate: number;
+  scheduledDate?: number;
+  status: string;
+  technicianName?: string;
+  notes?: string;
+};
+
+type Props = {
+  requests: Tour360Request[];
+  loading: boolean;
+  page: number;
+  totalPages: number;
+  onPageChange: (value: number) => void;
+};
+
+const Tour360RequestsGrid = ({
+  requests,
+  loading,
+  page,
+  totalPages,
+  onPageChange,
+}: Props) => {
+  const limit = 8;
+
+  if (loading) {
+    return (
+      <Grid container spacing={2}>
+        {Array.from(new Array(limit)).map((_, index) => (
+          <Grid key={index + "load"} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+            <Skeleton variant="rectangular" height={200} />
+          </Grid>
+        ))}
+      </Grid>
+    );
+  }
+
+  if (requests.length === 0) {
+    return (
+      <Box textAlign="center" mt={10}>
+        <Typography variant="h6" gutterBottom>
+          No hay solicitudes encontradas.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Grid container spacing={2}>
+        {requests.map((request) => (
+          <Grid key={request.environmentId} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+            <Tour360RequestCard
+              environmentName={request.environmentName}
+              status={request.status}
+              requestDate={request.requestDate}
+              scheduledDate={request.scheduledDate}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      {totalPages > 1 && (
+        <Box mt={4} display="flex" justifyContent="center">
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={(_, val) => onPageChange(val)}
+            color="primary"
+          />
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default Tour360RequestsGrid;

--- a/src/components/grid/Tour360RequestGrid.tsx
+++ b/src/components/grid/Tour360RequestGrid.tsx
@@ -31,7 +31,7 @@ const Tour360RequestsGrid = ({
 
   if (loading) {
     return (
-      <Grid container spacing={2}>
+      <Grid container spacing={2} sx={{ width: "100%" }}>
         {Array.from(new Array(limit)).map((_, index) => (
           <Grid key={index + "load"} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
             <Skeleton variant="rectangular" height={200} />
@@ -53,9 +53,12 @@ const Tour360RequestsGrid = ({
 
   return (
     <>
-      <Grid container spacing={2}>
+      <Grid container spacing={2} sx={{ width: "100%" }}>
         {requests.map((request) => (
-          <Grid key={request.environmentId} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+          <Grid
+            key={request.environmentId}
+            size={{ xs: 12, sm: 6, md: 4, lg: 3 }}
+          >
             <Tour360RequestCard
               environmentName={request.environmentName}
               status={request.status}

--- a/src/components/inputs/select/Tour360Filter.tsx
+++ b/src/components/inputs/select/Tour360Filter.tsx
@@ -1,0 +1,27 @@
+import { FormControl, InputLabel, Select, MenuItem } from "@mui/material";
+
+type Props = {
+  statusFilter: string;
+  onStatusChange: (value: string) => void;
+};
+
+const Tour360Filter = ({ statusFilter, onStatusChange }: Props) => {
+  return (
+    <FormControl sx={{ minWidth: 200 }}>
+      <InputLabel>Estado</InputLabel>
+      <Select
+        value={statusFilter}
+        onChange={(e) => onStatusChange(e.target.value)}
+        label="Estado"
+      >
+        <MenuItem value="">Todos</MenuItem>
+        <MenuItem value="Pending">Pendiente</MenuItem>
+        <MenuItem value="Scheduled">Programado</MenuItem>
+        <MenuItem value="Completed">Completado</MenuItem>
+        <MenuItem value="Cancelled">Cancelado</MenuItem>
+      </Select>
+    </FormControl>
+  );
+};
+
+export default Tour360Filter;


### PR DESCRIPTION
### What I did:
Created a new page to display all Tour360 requests with filtering by status and paginated results.

---

### How I did it:

Built a new page Tour360RequestsPage that fetches data from the backend (/api/tour360requests).

Added a status filter dropdown (Tour360Filter) to filter the requests by their current state (Pending, Scheduled, Completed, Cancelled).

Created a reusable card component (Tour360RequestCard) to display each tour request.

Created a reusable grid component (Tour360RequestsGrid) to display the list with pagination (limit = 8).

Divided the logic into small, reusable components to keep the page clean and maintainable.

---

### Why I did it:
To allow users to easily review, filter, and navigate through all Tour360 tour requests with a clear and organized UI in Spanish.