### PR TITLE
Feature/spacio 63/admin update tour360 status

### DIFF
--- a/src/components/card/Tour360RequestCard.tsx
+++ b/src/components/card/Tour360RequestCard.tsx
@@ -1,7 +1,22 @@
+"use client";
+
+import { authFetch } from "@/services/authFetch";
 import { PageRoutes } from "@/utils/constants/page-routes";
-import { AddOutlined } from "@mui/icons-material";
-import { Button, Card, CardContent, Typography } from "@mui/material";
+import {
+  AddOutlined,
+  SyncOutlined,
+} from "@mui/icons-material";
+import {
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  MenuItem,
+  Select,
+  Typography,
+} from "@mui/material";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 type Props = {
   publicId: string;
@@ -16,11 +31,24 @@ const Tour360RequestCard = ({
   publicId,
   environmentId,
   environmentName,
-  status,
+  status: initialStatus,
   requestDate,
   scheduledDate,
 }: Props) => {
   const router = useRouter();
+  const [status, setStatus] = useState(initialStatus);
+  const [loading, setLoading] = useState(false);
+
+  const handleStatusChange = async (newStatus: number) => {
+    setLoading(true);
+    try {
+
+    } catch (error) {
+      console.error("Fallo la solicitud:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <Card>
@@ -28,9 +56,27 @@ const Tour360RequestCard = ({
         <Typography variant="h6" gutterBottom>
           {environmentName}
         </Typography>
-        <Typography variant="body2">
-          Estado: {translateStatus(status)}
+
+        <Typography variant="body2" gutterBottom>
+          Estado:{" "}
+          {loading ? (
+            <CircularProgress size={16} />
+          ) : (
+            <Select
+              value={status}
+              size="small"
+              onChange={(e) => handleStatusChange(Number(e.target.value))}
+              sx={{ ml: 1 }}
+              startAdornment={<SyncOutlined fontSize="small" />}
+            >
+              <MenuItem value={0}>Pendiente</MenuItem>
+              <MenuItem value={1}>Programado</MenuItem>
+              <MenuItem value={2}>Completado</MenuItem>
+              <MenuItem value={3}>Cancelado</MenuItem>
+            </Select>
+          )}
         </Typography>
+
         <Typography variant="body2">
           Fecha de solicitud: {formatDate(requestDate)}
         </Typography>
@@ -60,21 +106,6 @@ const Tour360RequestCard = ({
 };
 
 // Helpers
-const translateStatus = (status: number) => {
-  switch (status) {
-    case 0:
-      return "Pendiente";
-    case 1:
-      return "Programado";
-    case 2:
-      return "Completado";
-    case 3:
-      return "Cancelado";
-    default:
-      return status;
-  }
-};
-
 const formatDate = (timestamp: number) => {
   const date = new Date(timestamp * 1000);
   return date.toLocaleDateString("es-ES");

--- a/src/components/card/Tour360RequestCard.tsx
+++ b/src/components/card/Tour360RequestCard.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { authFetch } from "@/services/authFetch";
+import { updateTour360Status } from "@/services/adminService";
 import { PageRoutes } from "@/utils/constants/page-routes";
+import { AddOutlined, SyncOutlined } from "@mui/icons-material";
 import {
-  AddOutlined,
-  SyncOutlined,
-} from "@mui/icons-material";
-import {
+  Box,
   Button,
   Card,
   CardContent,
@@ -41,13 +39,13 @@ const Tour360RequestCard = ({
 
   const handleStatusChange = async (newStatus: number) => {
     setLoading(true);
-    try {
-
-    } catch (error) {
-      console.error("Fallo la solicitud:", error);
-    } finally {
-      setLoading(false);
+    const success = await updateTour360Status(publicId, newStatus);
+    if (success) {
+      setStatus(newStatus);
+    } else {
+      alert("No se pudo actualizar el estado, inténtalo de nuevo");
     }
+    setLoading(false);
   };
 
   return (
@@ -57,8 +55,11 @@ const Tour360RequestCard = ({
           {environmentName}
         </Typography>
 
-        <Typography variant="body2" gutterBottom>
-          Estado:{" "}
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Typography variant="body2" gutterBottom>
+            Estado:{" "}
+          </Typography>
+
           {loading ? (
             <CircularProgress size={16} />
           ) : (
@@ -75,7 +76,7 @@ const Tour360RequestCard = ({
               <MenuItem value={3}>Cancelado</MenuItem>
             </Select>
           )}
-        </Typography>
+        </Box>
 
         <Typography variant="body2">
           Fecha de solicitud: {formatDate(requestDate)}

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -76,3 +76,26 @@ export const uploadVirtualTour = async (
     throw new Error(`Error al subir el recorrido: ${errorText}`);
   }
 };
+
+export const updateTour360Status = async (
+  publicId: string,
+  newStatus: number,
+): Promise<boolean> => {
+  try {
+    const res = await authFetch(
+      `http://localhost:5101/api/tour360requests/${publicId}/status`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status: newStatus }),
+        credentials: "include",
+      },
+    );
+
+    return res.ok;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
### What I Did

* Added a status selector to the `Tour360RequestCard` component.
* Implemented a loading indicator when updating the tour status.
* Created a `tour360.service.ts` to handle the status update request via `authFetch`.

---

### Why I Did It

* To allow users to manually update the status of a 360 tour request directly from the UI.
* To improve user feedback and experience by showing a loading state.
* To keep the component clean and delegate network logic to a dedicated service.

---

### How I Did It

* Added a `Select` input with all possible tour statuses and linked it to a handler.
* The handler uses the `updateTour360Status` service function to call the backend `PATCH` endpoint.
* Wrapped the request in a `loading` state using `useState`.
* Used `authFetch` to handle session and token refresh logic.