### PR TITLE
Feature/spacio 90/bookings calendar

### DIFF
--- a/src/app/buscar/page.tsx
+++ b/src/app/buscar/page.tsx
@@ -6,12 +6,16 @@ import { Environment } from "@/types/AllEnvironments";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import EnvironmentGrid from "@/components/grid/EnvironmentGrid";
 import { fetchEnvironments } from "@/services/environmentService";
+import { useSelector } from "react-redux";
+import { RootState } from "@/store";
 
 const EnvironmentsPage = () => {
   const [environments, setEnvironments] = useState<Environment[]>([]);
   const [loading, setLoading] = useState(true);
   const [totalPages, setTotalPages] = useState(1);
   const searchParams = useSearchParams();
+
+  const user = useSelector((state: RootState) => state.user);
   const router = useRouter();
 
   const page = parseInt(searchParams.get("page") || "1", 10);
@@ -42,7 +46,7 @@ const EnvironmentsPage = () => {
 
   return (
     <EnvironmentGrid
-      environments={environments}
+      environments={environments.filter((env) => env.ownerId !== user.publicId)}
       loading={loading}
       totalPages={totalPages}
       page={page}

--- a/src/app/calendario/page.tsx
+++ b/src/app/calendario/page.tsx
@@ -12,6 +12,7 @@ import { RootState } from "@/store";
 import { UserRole } from "@/types/Users";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import OwnerDailyReservations from "@/components/list/OwnerDailyReservations";
+import BlockedEnvironments from "@/components/list/BlockedEnvironments";
 
 const OwnerBlockedCalendar: React.FC = () => {
   const [selectedDate, setSelectedDate] = useState<Moment | null>(null);
@@ -42,9 +43,14 @@ const OwnerBlockedCalendar: React.FC = () => {
         </LocalizationProvider>
       </Box>
       {selectedDate && (
-        <Box mt={4}>
-          <OwnerDailyReservations date={selectedDate} />
-        </Box>
+        <>
+          <Box mt={4}>
+            <OwnerDailyReservations date={selectedDate} />
+          </Box>
+          <Box mt={4}>
+            <BlockedEnvironments date={selectedDate} />
+          </Box>
+        </>
       )}
     </>
   );

--- a/src/app/calendario/page.tsx
+++ b/src/app/calendario/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Box } from "@mui/material";
+import { Box, Button } from "@mui/material";
 import { DateCalendar } from "@mui/x-date-pickers/DateCalendar";
 import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -13,9 +13,14 @@ import { UserRole } from "@/types/Users";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import OwnerDailyReservations from "@/components/list/OwnerDailyReservations";
 import BlockedEnvironments from "@/components/list/BlockedEnvironments";
+import BlockTimeDialog from "@/components/modal/BlockTimeDialog";
+import { BlockedDate } from "@/types/Availability";
 
 const OwnerBlockedCalendar: React.FC = () => {
   const [selectedDate, setSelectedDate] = useState<Moment | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [blockedItems, setBlockedItems] = useState<BlockedDate[]>([]);
+
   const role = useSelector((state: RootState) => state.user.role);
   const router = useRouter();
 
@@ -48,9 +53,38 @@ const OwnerBlockedCalendar: React.FC = () => {
             <OwnerDailyReservations date={selectedDate} />
           </Box>
           <Box mt={4}>
-            <BlockedEnvironments date={selectedDate} />
+            <BlockedEnvironments
+              date={selectedDate}
+              onLoad={(items) => setBlockedItems(items)}
+            />
           </Box>
         </>
+      )}
+      {selectedDate && (
+        <Box mt={2} display="flex" justifyContent="center">
+          <Button
+            onClick={() => setDialogOpen(true)}
+            style={{
+              padding: "8px 16px",
+              backgroundColor: "#1976d2",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+            }}
+            variant="outlined"
+          >
+            Bloquear Fecha/Horario de Ambiente
+          </Button>
+        </Box>
+      )}
+      {selectedDate && (
+        <BlockTimeDialog
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+          selectedDate={selectedDate}
+          existingBlocks={blockedItems}
+        />
       )}
     </>
   );

--- a/src/app/calendario/page.tsx
+++ b/src/app/calendario/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Box } from "@mui/material";
+import { DateCalendar } from "@mui/x-date-pickers/DateCalendar";
+import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { Moment } from "moment";
+import { useSelector } from "react-redux";
+import { useRouter } from "next/navigation";
+import { RootState } from "@/store";
+import { UserRole } from "@/types/Users";
+import { PageRoutes } from "@/utils/constants/page-routes";
+import OwnerDailyReservations from "@/components/list/OwnerDailyReservations";
+
+const OwnerBlockedCalendar: React.FC = () => {
+  const [selectedDate, setSelectedDate] = useState<Moment | null>(null);
+  const role = useSelector((state: RootState) => state.user.role);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!role || role !== UserRole.Owner) {
+      router.push(PageRoutes.Home);
+    }
+  }, [role, router]);
+
+  return (
+    <>
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: 420,
+          mx: "auto",
+          mt: 2,
+        }}
+      >
+        <LocalizationProvider dateAdapter={AdapterMoment}>
+          <DateCalendar
+            value={selectedDate}
+            onChange={(newValue) => setSelectedDate(newValue)}
+          />
+        </LocalizationProvider>
+      </Box>
+      {selectedDate && (
+        <Box mt={4}>
+          <OwnerDailyReservations date={selectedDate} />
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default OwnerBlockedCalendar;

--- a/src/components/list/BlockedEnvironments.tsx
+++ b/src/components/list/BlockedEnvironments.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  CircularProgress,
+  Grid,
+  Avatar,
+} from "@mui/material";
+import moment, { Moment } from "moment";
+import { getBlockedEnvironmentsByDay } from "@/services/availabilityService";
+
+type Props = {
+  date: Moment;
+};
+
+const BlockedEnvironments: React.FC<Props> = ({ date }) => {
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<
+    {
+      environmentTitle: string;
+      environmentPhotoUrl?: string;
+      startDate: number;
+      endDate: number;
+    }[]
+  >([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchBlocked = async () => {
+      try {
+        setLoading(true);
+        const timestamp = date.startOf("day").valueOf();
+        const res = await getBlockedEnvironmentsByDay(timestamp);
+        setItems(res);
+      } catch (err) {
+        setError("Error al cargar ambientes bloqueados.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBlocked();
+  }, [date]);
+
+  if (loading) {
+    return (
+      <Box textAlign="center" mt={2}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box textAlign="center" mt={2}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!items.length) {
+    return (
+      <Box textAlign="center" mt={2}>
+        <Typography>No hay ambientes bloqueados este día.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box mt={2}>
+      <Typography variant="h6" mb={2}>
+        Ambientes Bloqueados
+      </Typography>
+
+      {items.map((item, index) => {
+        const start = moment(item.startDate).format("HH:mm");
+        const end = moment(item.endDate).format("HH:mm");
+
+        return (
+          <Card key={index} sx={{ mb: 2 }}>
+            <CardContent>
+              <Grid container spacing={2}>
+                <Grid size={{ xs: 3 }}>
+                  <Avatar
+                    variant="rounded"
+                    src={item.environmentPhotoUrl}
+                    sx={{ width: "100%", height: 80 }}
+                  />
+                </Grid>
+                <Grid size={{ xs: 9 }}>
+                  <Typography fontWeight="bold">
+                    {item.environmentTitle}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {start} → {end}
+                  </Typography>
+                </Grid>
+              </Grid>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default BlockedEnvironments;

--- a/src/components/list/BlockedEnvironments.tsx
+++ b/src/components/list/BlockedEnvironments.tsx
@@ -12,21 +12,16 @@ import {
 } from "@mui/material";
 import moment, { Moment } from "moment";
 import { getBlockedEnvironmentsByDay } from "@/services/availabilityService";
+import { BlockedDate } from "@/types/Availability";
 
 type Props = {
   date: Moment;
+  onLoad: (items: BlockedDate[]) => void;
 };
 
-const BlockedEnvironments: React.FC<Props> = ({ date }) => {
+const BlockedEnvironments: React.FC<Props> = ({ date, onLoad }) => {
   const [loading, setLoading] = useState(true);
-  const [items, setItems] = useState<
-    {
-      environmentTitle: string;
-      environmentPhotoUrl?: string;
-      startDate: number;
-      endDate: number;
-    }[]
-  >([]);
+  const [items, setItems] = useState<BlockedDate[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -36,7 +31,7 @@ const BlockedEnvironments: React.FC<Props> = ({ date }) => {
         const timestamp = date.startOf("day").valueOf();
         const res = await getBlockedEnvironmentsByDay(timestamp);
         setItems(res);
-      } catch (err) {
+      } catch {
         setError("Error al cargar ambientes bloqueados.");
       } finally {
         setLoading(false);
@@ -45,6 +40,10 @@ const BlockedEnvironments: React.FC<Props> = ({ date }) => {
 
     fetchBlocked();
   }, [date]);
+
+  useEffect(() => {
+    onLoad(items);
+  }, [items, onLoad]);
 
   if (loading) {
     return (

--- a/src/components/list/OwnerDailyReservations.tsx
+++ b/src/components/list/OwnerDailyReservations.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, CircularProgress, Typography } from "@mui/material";
+import { ReservationResponse } from "@/types/Reservations";
+import { getReservationsByDay } from "@/services/reservationService";
+import moment, { Moment } from "moment";
+import ReservationList from "../card/ReservationList";
+
+type Props = {
+  date: Moment;
+};
+
+const OwnerDailyReservations: React.FC<Props> = ({ date }) => {
+  const [loading, setLoading] = useState(true);
+  const [reservations, setReservations] = useState<ReservationResponse[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchReservations = async () => {
+      try {
+        setLoading(true);
+        const timestamp = date.startOf("day").valueOf();
+        const res = await getReservationsByDay(timestamp);
+        setReservations(res);
+      } catch (err) {
+        setError("Error al cargar las reservas.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchReservations();
+  }, [date]);
+
+  if (loading) {
+    return (
+      <Box mt={4} textAlign="center">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box mt={4} textAlign="center">
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  return <ReservationList reservations={reservations} />;
+};
+
+export default OwnerDailyReservations;

--- a/src/components/list/OwnerDailyReservations.tsx
+++ b/src/components/list/OwnerDailyReservations.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { Box, CircularProgress, Typography } from "@mui/material";
 import { ReservationResponse } from "@/types/Reservations";
 import { getReservationsByDay } from "@/services/reservationService";
-import moment, { Moment } from "moment";
+import { Moment } from "moment";
 import ReservationList from "../card/ReservationList";
 
 type Props = {
@@ -23,7 +23,7 @@ const OwnerDailyReservations: React.FC<Props> = ({ date }) => {
         const timestamp = date.startOf("day").valueOf();
         const res = await getReservationsByDay(timestamp);
         setReservations(res);
-      } catch (err) {
+      } catch {
         setError("Error al cargar las reservas.");
       } finally {
         setLoading(false);

--- a/src/components/modal/BlockTimeDialog.tsx
+++ b/src/components/modal/BlockTimeDialog.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+  Box,
+  Alert,
+} from "@mui/material";
+import moment from "moment";
+import { getOwnerEnvironments } from "@/services/environmentService";
+import { blockEnvironment } from "@/services/availabilityService";
+import { Environment } from "@/types/GetEnvironment";
+import Image from "next/image";
+
+type BlockTimeDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  selectedDate: moment.Moment;
+  existingBlocks: {
+    environmentId: string;
+    startDate: number;
+    endDate: number;
+  }[];
+};
+
+const BlockTimeDialog: React.FC<BlockTimeDialogProps> = ({
+  open,
+  onClose,
+  selectedDate,
+  existingBlocks,
+}) => {
+  const [environments, setEnvironments] = useState<Environment[]>([]);
+  const [environmentId, setEnvironmentId] = useState<string>("");
+  const [startHour, setStartHour] = useState("00:00");
+  const [endHour, setEndHour] = useState("23:59");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const selectedEnvironment = environments.find(
+    (e) => e.publicId === environmentId,
+  );
+  const isHospedaje = selectedEnvironment?.type.publicKey === "hospedajes";
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await getOwnerEnvironments();
+      setEnvironments(data.items);
+    };
+    load();
+  }, []);
+
+  const handleBlock = async () => {
+    setError(null);
+
+    if (!environmentId) {
+      setError("Debes seleccionar un ambiente.");
+      return;
+    }
+
+    let startTime: number;
+    let endTime: number;
+
+    if (isHospedaje) {
+      startTime = selectedDate.clone().startOf("day").valueOf();
+      endTime = selectedDate.clone().endOf("day").valueOf();
+    } else {
+      const [startHourStr, startMinuteStr] = startHour.split(":");
+      const [endHourStr, endMinuteStr] = endHour.split(":");
+
+      startTime = selectedDate
+        .clone()
+        .set({
+          hour: parseInt(startHourStr, 10),
+          minute: parseInt(startMinuteStr, 10),
+        })
+        .valueOf();
+
+      endTime = selectedDate
+        .clone()
+        .set({
+          hour: parseInt(endHourStr, 10),
+          minute: parseInt(endMinuteStr, 10),
+        })
+        .valueOf();
+    }
+
+    const hasConflict = existingBlocks.some((item) => {
+      if (item.environmentId !== environmentId) return false;
+      return (
+        (startTime >= item.startDate && startTime < item.endDate) ||
+        (endTime > item.startDate && endTime <= item.endDate) ||
+        (startTime <= item.startDate && endTime >= item.endDate)
+      );
+    });
+
+    if (hasConflict) {
+      setError("Ya existe un bloqueo para este ambiente en ese horario.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await blockEnvironment({
+        environmentId,
+        startDate: startTime,
+        endDate: endTime,
+      });
+      onClose();
+    } catch {
+      setError("Error al bloquear el horario.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>Bloquear horario</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Fecha seleccionada: <b>{selectedDate.format("DD MMM YYYY")}</b>
+        </Typography>
+
+        <Box mt={2}>
+          <Select
+            fullWidth
+            value={environmentId}
+            onChange={(e) => setEnvironmentId(e.target.value)}
+            displayEmpty
+          >
+            <MenuItem value="" disabled>
+              Selecciona un ambiente
+            </MenuItem>
+            {environments.map((env) => (
+              <MenuItem key={env.publicId} value={env.publicId}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Image
+                    src={env.photos?.[0].url}
+                    alt={env.title}
+                    width={40}
+                    height={40}
+                    style={{ objectFit: "cover", borderRadius: 4 }}
+                  />
+                  <Typography>{env.title}</Typography>
+                </Box>
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+
+        {!isHospedaje && (
+          <Box mt={2} display="flex" gap={2}>
+            <TextField
+              label="Hora de inicio"
+              type="time"
+              value={startHour}
+              onChange={(e) => setStartHour(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Hora de fin"
+              type="time"
+              value={endHour}
+              onChange={(e) => setEndHour(e.target.value)}
+              fullWidth
+            />
+          </Box>
+        )}
+
+        {error && (
+          <Box mt={2}>
+            <Alert severity="error">{error}</Alert>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button onClick={handleBlock} variant="contained" disabled={loading}>
+          Bloquear
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default BlockTimeDialog;

--- a/src/services/availabilityService.ts
+++ b/src/services/availabilityService.ts
@@ -1,22 +1,23 @@
 export const loadUnavailableRanges = async (
   publicId: string,
   startMs: number,
-  endMs: number
+  endMs: number,
 ): Promise<{ start: number; end: number }[]> => {
   const start = Math.floor(startMs / 1000);
   const end = Math.floor(endMs / 1000);
 
   const res = await fetch(
-    `http://localhost:5150/api/availability/unavailable?envId=${publicId}&start=${start}&end=${end}`
+    `http://localhost:5150/api/Availability/unavailable?envId=${publicId}&start=${start}&end=${end}`,
   );
   if (!res.ok) throw new Error("Error loading unavailable ranges");
   return await res.json();
 };
 
 export const getBlockedEnvironmentsByDay = async (
-  timestamp: number
+  timestamp: number,
 ): Promise<
   {
+    environmentId: string;
     environmentTitle: string;
     environmentPhotoUrl?: string;
     startDate: number;
@@ -27,11 +28,41 @@ export const getBlockedEnvironmentsByDay = async (
     `http://localhost:5150/api/Availability/blocked?timestamp=${timestamp}`,
     {
       credentials: "include",
-    }
+    },
   );
 
   if (!res.ok) {
     throw new Error("Error al obtener ambientes bloqueados");
+  }
+
+  return await res.json();
+};
+
+export const blockEnvironment = async ({
+  environmentId,
+  startDate,
+  endDate,
+}: {
+  environmentId: string;
+  startDate: number;
+  endDate: number;
+}) => {
+  const res = await fetch("http://localhost:5150/api/Availability/block", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify({
+      environmentId,
+      startDate,
+      endDate,
+    }),
+  });
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => null);
+    throw new Error(error?.mensaje || "Error al bloquear el ambiente");
   }
 
   return await res.json();

--- a/src/services/availabilityService.ts
+++ b/src/services/availabilityService.ts
@@ -1,14 +1,38 @@
 export const loadUnavailableRanges = async (
   publicId: string,
   startMs: number,
-  endMs: number,
+  endMs: number
 ): Promise<{ start: number; end: number }[]> => {
-  const start = Math.floor(startMs / 1000); // 👈 convierte a segundos
+  const start = Math.floor(startMs / 1000);
   const end = Math.floor(endMs / 1000);
 
   const res = await fetch(
-    `http://localhost:5150/api/availability/unavailable?envId=${publicId}&start=${start}&end=${end}`,
+    `http://localhost:5150/api/availability/unavailable?envId=${publicId}&start=${start}&end=${end}`
   );
   if (!res.ok) throw new Error("Error loading unavailable ranges");
+  return await res.json();
+};
+
+export const getBlockedEnvironmentsByDay = async (
+  timestamp: number
+): Promise<
+  {
+    environmentTitle: string;
+    environmentPhotoUrl?: string;
+    startDate: number;
+    endDate: number;
+  }[]
+> => {
+  const res = await fetch(
+    `http://localhost:5150/api/Availability/blocked?timestamp=${timestamp}`,
+    {
+      credentials: "include",
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error("Error al obtener ambientes bloqueados");
+  }
+
   return await res.json();
 };

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -5,7 +5,7 @@ import {
 } from "@/types/Reservations";
 
 export const createReservation = async (
-  payload: CreateReservationPayload
+  payload: CreateReservationPayload,
 ): Promise<void> => {
   const res = await fetch("http://localhost:5150/api/reservations", {
     method: "POST",
@@ -23,7 +23,7 @@ export const createReservation = async (
 export const getMyReservations = async (
   status: string = "confirmed",
   page: number = 1,
-  limit: number = 10
+  limit: number = 10,
 ): Promise<PagedResult<ReservationResponse>> => {
   const params = new URLSearchParams({
     status,
@@ -36,7 +36,7 @@ export const getMyReservations = async (
     {
       method: "GET",
       credentials: "include",
-    }
+    },
   );
 
   if (!res.ok) {
@@ -48,13 +48,13 @@ export const getMyReservations = async (
 };
 
 export const getReservationById = async (
-  publicId: string
+  publicId: string,
 ): Promise<ReservationResponse> => {
   const res = await fetch(
     `http://localhost:5150/api/Reservations/${publicId}`,
     {
       credentials: "include",
-    }
+    },
   );
 
   if (!res.ok) {
@@ -66,7 +66,7 @@ export const getReservationById = async (
 
 export const updateReservationStatus = async (
   publicId: string,
-  newStatus: string
+  newStatus: string,
 ): Promise<void> => {
   const res = await fetch(
     `http://localhost:5150/api/Reservations/${publicId}/status`,
@@ -77,7 +77,7 @@ export const updateReservationStatus = async (
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ status: newStatus }),
-    }
+    },
   );
 
   if (!res.ok) {
@@ -89,7 +89,7 @@ export const updateReservationStatus = async (
 export const checkReservationConflicts = async (
   environmentId: string,
   start: number,
-  end: number
+  end: number,
 ): Promise<boolean> => {
   const params = new URLSearchParams({
     environmentId,
@@ -102,7 +102,7 @@ export const checkReservationConflicts = async (
     {
       method: "GET",
       credentials: "include",
-    }
+    },
   );
 
   if (!res.ok) {
@@ -114,13 +114,13 @@ export const checkReservationConflicts = async (
 };
 
 export const getReservationsByDay = async (
-  timestamp: number
+  timestamp: number,
 ): Promise<ReservationResponse[]> => {
   const res = await fetch(
     `http://localhost:5150/api/Reservations/day?timestamp=${timestamp}`,
     {
       credentials: "include",
-    }
+    },
   );
 
   if (!res.ok) {

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -5,7 +5,7 @@ import {
 } from "@/types/Reservations";
 
 export const createReservation = async (
-  payload: CreateReservationPayload,
+  payload: CreateReservationPayload
 ): Promise<void> => {
   const res = await fetch("http://localhost:5150/api/reservations", {
     method: "POST",
@@ -23,7 +23,7 @@ export const createReservation = async (
 export const getMyReservations = async (
   status: string = "confirmed",
   page: number = 1,
-  limit: number = 10,
+  limit: number = 10
 ): Promise<PagedResult<ReservationResponse>> => {
   const params = new URLSearchParams({
     status,
@@ -36,7 +36,7 @@ export const getMyReservations = async (
     {
       method: "GET",
       credentials: "include",
-    },
+    }
   );
 
   if (!res.ok) {
@@ -48,13 +48,13 @@ export const getMyReservations = async (
 };
 
 export const getReservationById = async (
-  publicId: string,
+  publicId: string
 ): Promise<ReservationResponse> => {
   const res = await fetch(
     `http://localhost:5150/api/Reservations/${publicId}`,
     {
       credentials: "include",
-    },
+    }
   );
 
   if (!res.ok) {
@@ -66,7 +66,7 @@ export const getReservationById = async (
 
 export const updateReservationStatus = async (
   publicId: string,
-  newStatus: string,
+  newStatus: string
 ): Promise<void> => {
   const res = await fetch(
     `http://localhost:5150/api/Reservations/${publicId}/status`,
@@ -77,7 +77,7 @@ export const updateReservationStatus = async (
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ status: newStatus }),
-    },
+    }
   );
 
   if (!res.ok) {
@@ -89,7 +89,7 @@ export const updateReservationStatus = async (
 export const checkReservationConflicts = async (
   environmentId: string,
   start: number,
-  end: number,
+  end: number
 ): Promise<boolean> => {
   const params = new URLSearchParams({
     environmentId,
@@ -102,7 +102,7 @@ export const checkReservationConflicts = async (
     {
       method: "GET",
       credentials: "include",
-    },
+    }
   );
 
   if (!res.ok) {
@@ -111,4 +111,21 @@ export const checkReservationConflicts = async (
 
   const { hasConflict } = await res.json();
   return hasConflict;
+};
+
+export const getReservationsByDay = async (
+  timestamp: number
+): Promise<ReservationResponse[]> => {
+  const res = await fetch(
+    `http://localhost:5150/api/Reservations/day?timestamp=${timestamp}`,
+    {
+      credentials: "include",
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error("Error al obtener las reservas del día");
+  }
+
+  return await res.json();
 };

--- a/src/types/AllEnvironments.ts
+++ b/src/types/AllEnvironments.ts
@@ -14,6 +14,7 @@ export interface PricingPolicy {
 
 export interface Environment {
   publicId: string;
+  ownerId: string;
   title: string;
   description: string;
   location: string;

--- a/src/types/Availability.ts
+++ b/src/types/Availability.ts
@@ -1,0 +1,7 @@
+export interface BlockedDate {
+  environmentId: string;
+  environmentTitle: string;
+  environmentPhotoUrl?: string;
+  startDate: number;
+  endDate: number;
+}

--- a/src/utils/constants/page-routes.ts
+++ b/src/utils/constants/page-routes.ts
@@ -8,7 +8,7 @@ export enum PageRoutes {
   Profile = "/perfil",
   Shots_360 = "/capturas360",
   Create_Virtual_Tour = "/capturas360/crear",
-  Calendar = "/calendar",
+  Calendar = "/calendario",
   Debts = "/deudas",
   Search = "/buscar",
   Environment_Details = "/detalles",


### PR DESCRIPTION
### What I did

Implemented the frontend functionality that allows owners to block specific date/time ranges for their environments directly from a calendar view.

---

### Why I did it

To provide owners with an intuitive and visual way to manage availability by selecting a date on a calendar and blocking time slots for maintenance, private use, or other reasons. This helps prevent bookings during those periods.

---

### How I did it

* Added a `DateCalendar` component to select a date.
* Displayed owner reservations and existing blocked environments for the selected day.
* Implemented a `BlockTimeDialog` that:

  * Shows a list of the owner’s environments (with image and title).
  * Allows selection of time ranges (or blocks full day if the environment is for lodging).
  * Validates UI-side for time conflicts with existing blocks.
  * Sends a `POST /api/Availability/block` request with the selected data.