### PR TITLE
Feature/spacio 136/filter environments by detected objects

### DIFF
--- a/src/components/card/EnvironmentCard.tsx
+++ b/src/components/card/EnvironmentCard.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import { Environment } from "@/types/AllEnvironments";
+import { CLASS_ID_TO_NAME } from "@/utils/constants/class-names";
 import { PageRoutes } from "@/utils/constants/page-routes";
-import { Card, CardContent, CardMedia, Typography } from "@mui/material";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardMedia,
+  Chip,
+  Typography,
+} from "@mui/material";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
 
 interface Props {
   environment: Environment;
@@ -40,6 +49,41 @@ const EnvironmentCard = ({ environment }: Props) => {
     router.push(path);
   };
 
+  const userEquipmentFilter = useMemo(() => {
+    const filters: string[] = [];
+    searchParams.forEach((value, key) => {
+      if (key.startsWith("equipment_")) {
+        filters.push(key.replace("equipment_", ""));
+      }
+    });
+    return filters;
+  }, [searchParams]);
+
+  const equipmentChips = useMemo(() => {
+    if (!environment.equipment) return [];
+
+    let equipmentDict: Record<string, number> = {};
+
+    try {
+      equipmentDict = JSON.parse(environment.equipment);
+    } catch {
+      return [];
+    }
+
+    return Object.entries(equipmentDict)
+      .filter(([_, qty]) => qty > 0)
+      .sort((a, b) => {
+        const [aId, aQty] = a;
+        const [bId, bQty] = b;
+
+        const aIsFiltered = userEquipmentFilter.includes(aId) ? 0 : 1;
+        const bIsFiltered = userEquipmentFilter.includes(bId) ? 0 : 1;
+
+        if (aIsFiltered !== bIsFiltered) return aIsFiltered - bIsFiltered;
+        return (bQty as number) - (aQty as number);
+      });
+  }, [environment.equipment, userEquipmentFilter]);
+
   return (
     <div onClick={handleNavigate}>
       <Card sx={{ borderRadius: 2, cursor: "pointer", height: "100%" }}>
@@ -61,8 +105,22 @@ const EnvironmentCard = ({ environment }: Props) => {
             {pricingPolicies[0]?.priceUnit.toLowerCase()}
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            👥 {capacity} asistentes
+            👥 Máx: {capacity} asistentes
           </Typography>
+          {equipmentChips.length > 0 && (
+            <Box display="flex" flexWrap="wrap" gap={0.5} mt={1}>
+              {equipmentChips.map(([id, qty]) => (
+                <Chip
+                  key={id}
+                  label={`${CLASS_ID_TO_NAME[id] || id} (${qty})`}
+                  size="small"
+                  color={
+                    userEquipmentFilter.includes(id) ? "primary" : "default"
+                  }
+                />
+              ))}
+            </Box>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/card/EnvironmentCard.tsx
+++ b/src/components/card/EnvironmentCard.tsx
@@ -71,7 +71,7 @@ const EnvironmentCard = ({ environment }: Props) => {
     }
 
     return Object.entries(equipmentDict)
-      .filter(([_, qty]) => qty > 0)
+      .filter(([, qty]) => qty > 0)
       .sort((a, b) => {
         const [aId, aQty] = a;
         const [bId, bQty] = b;

--- a/src/components/modal/FiltersModal.tsx
+++ b/src/components/modal/FiltersModal.tsx
@@ -84,7 +84,7 @@ export default function FiltersModal({
     delta: number,
     state: Record<string, number>,
     setState: (s: Record<string, number>) => void,
-    maxLimit = Infinity
+    maxLimit = Infinity,
   ) => {
     const newValue = Math.max(0, Math.min((state[key] || 0) + delta, maxLimit));
     setState({
@@ -97,7 +97,7 @@ export default function FiltersModal({
     setSelectedServices(
       selectedServices.includes(key)
         ? selectedServices.filter((s) => s !== key)
-        : [...selectedServices, key]
+        : [...selectedServices, key],
     );
   };
 
@@ -208,7 +208,7 @@ export default function FiltersModal({
                     area.publicKey,
                     -1,
                     areaCounts,
-                    setAreaCounts
+                    setAreaCounts,
                   )
                 }
               >
@@ -226,7 +226,7 @@ export default function FiltersModal({
                     1,
                     areaCounts,
                     setAreaCounts,
-                    4
+                    4,
                   )
                 }
                 disabled={areaCounts[area.publicKey] >= 4}

--- a/src/components/modal/FiltersModal.tsx
+++ b/src/components/modal/FiltersModal.tsx
@@ -25,8 +25,10 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { useSelector } from "react-redux";
 import { RootState } from "@/store";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ColorPalette } from "@/utils/constants/ui-constants";
+import { fetchAvailableEquipment } from "@/services/environmentService";
+import { CLASS_ID_TO_NAME } from "@/utils/constants/class-names";
 
 interface FiltersModalProps {
   open: boolean;
@@ -64,13 +66,25 @@ export default function FiltersModal({
 
   const [expandedServices, setExpandedServices] = useState(false);
   const [expandedAreas, setExpandedAreas] = useState(false);
+  const [availableEquipment, setAvailableEquipment] = useState<
+    { name: string; count: number }[]
+  >([]);
+
+  useEffect(() => {
+    if (open) {
+      const params = new URLSearchParams(window.location.search);
+      fetchAvailableEquipment(params)
+        .then(setAvailableEquipment)
+        .catch((e) => console.error("Error loading equipment", e));
+    }
+  }, [open]);
 
   const handleCountChange = (
     key: string,
     delta: number,
     state: Record<string, number>,
     setState: (s: Record<string, number>) => void,
-    maxLimit = Infinity,
+    maxLimit = Infinity
   ) => {
     const newValue = Math.max(0, Math.min((state[key] || 0) + delta, maxLimit));
     setState({
@@ -83,7 +97,7 @@ export default function FiltersModal({
     setSelectedServices(
       selectedServices.includes(key)
         ? selectedServices.filter((s) => s !== key)
-        : [...selectedServices, key],
+        : [...selectedServices, key]
     );
   };
 
@@ -194,7 +208,7 @@ export default function FiltersModal({
                     area.publicKey,
                     -1,
                     areaCounts,
-                    setAreaCounts,
+                    setAreaCounts
                   )
                 }
               >
@@ -212,7 +226,7 @@ export default function FiltersModal({
                     1,
                     areaCounts,
                     setAreaCounts,
-                    4,
+                    4
                   )
                 }
                 disabled={areaCounts[area.publicKey] >= 4}
@@ -229,6 +243,42 @@ export default function FiltersModal({
         >
           {expandedAreas ? "Mostrar menos" : "Mostrar más"}
         </Button>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+          Equipamiento
+        </Typography>
+        {availableEquipment.map((item) => (
+          <Box
+            key={item.name}
+            display="flex"
+            justifyContent="space-between"
+            my={1}
+          >
+            <Typography>{CLASS_ID_TO_NAME[item.name]}</Typography>
+            <Box display="flex" alignItems="center">
+              <IconButton
+                onClick={() =>
+                  handleCountChange(item.name, -1, areaCounts, setAreaCounts)
+                }
+              >
+                <RemoveIcon />
+              </IconButton>
+              <Typography>
+                {areaCounts[item.name] >= 4 ? "4+" : areaCounts[item.name] || 0}
+              </Typography>
+              <IconButton
+                onClick={() =>
+                  handleCountChange(item.name, 1, areaCounts, setAreaCounts, 4)
+                }
+                disabled={areaCounts[item.name] >= 4}
+              >
+                <AddIcon />
+              </IconButton>
+            </Box>
+          </Box>
+        ))}
 
         <Divider sx={{ my: 2 }} />
 

--- a/src/services/environmentService.ts
+++ b/src/services/environmentService.ts
@@ -46,11 +46,11 @@ export const createEnvironment = async (formData: FormDataCreateEnv) => {
   data.append("weeklySchedulesJson", JSON.stringify(formData.weeklySchedules));
   data.append(
     "discountPoliciesJson",
-    JSON.stringify(formData.discountPolicies)
+    JSON.stringify(formData.discountPolicies),
   );
   data.append(
     "servicePublicKeysJson",
-    JSON.stringify(formData.servicePublicKeys)
+    JSON.stringify(formData.servicePublicKeys),
   );
 
   try {
@@ -75,7 +75,7 @@ export const createEnvironment = async (formData: FormDataCreateEnv) => {
 export const fetchEnvironments = async (
   searchParams: URLSearchParams,
   page: number,
-  limit: number
+  limit: number,
 ) => {
   try {
     const areas: Area[] = [];
@@ -133,7 +133,7 @@ export const fetchEnvironments = async (
           "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
-      }
+      },
     );
 
     if (!res.ok) {
@@ -148,7 +148,7 @@ export const fetchEnvironments = async (
 };
 
 export const fetchAvailableEquipment = async (
-  searchParams: URLSearchParams
+  searchParams: URLSearchParams,
 ): Promise<{ name: string; count: number }[]> => {
   const areas: Area[] = [];
   searchParams.forEach((value, key) => {
@@ -194,7 +194,7 @@ export const fetchAvailableEquipment = async (
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
-    }
+    },
   );
 
   if (!res.ok) {
@@ -211,7 +211,7 @@ export const getOwnerEnvironments = async (page = 1, limit = 10) => {
       {
         method: "GET",
         credentials: "include",
-      }
+      },
     );
 
     if (!res.ok) {
@@ -229,7 +229,7 @@ export const getOwnerEnvironments = async (page = 1, limit = 10) => {
 export const getEnvironmentByPublicId = async (publicId: string) => {
   try {
     const res = await fetch(
-      `http://localhost:5150/api/environments/single?publicId=${publicId}`
+      `http://localhost:5150/api/environments/single?publicId=${publicId}`,
     );
 
     if (!res.ok) {

--- a/src/services/environmentService.ts
+++ b/src/services/environmentService.ts
@@ -79,12 +79,19 @@ export const fetchEnvironments = async (
 ) => {
   try {
     const areas: Area[] = [];
+    const equipmentRequired: Record<string, number> = {};
+
     searchParams.forEach((value, key) => {
       if (key.startsWith("area_")) {
         areas.push({
           AreaPublicKey: key.replace("area_", ""),
           MinQuantity: parseInt(value),
         });
+      }
+
+      if (key.startsWith("equipment_")) {
+        const objectId = key.replace("equipment_", "");
+        equipmentRequired[objectId] = parseInt(value);
       }
     });
 
@@ -112,6 +119,10 @@ export const fetchEnvironments = async (
       minCapacity: searchParams.get("minCapacity")
         ? parseFloat(searchParams.get("minCapacity")!)
         : 0,
+      equipmentRequired:
+        Object.keys(equipmentRequired).length > 0
+          ? equipmentRequired
+          : undefined,
     };
 
     const res = await fetch(
@@ -191,7 +202,7 @@ export const fetchAvailableEquipment = async (
   }
 
   return await res.json();
-}
+};
 
 export const getOwnerEnvironments = async (page = 1, limit = 10) => {
   try {

--- a/src/services/environmentService.ts
+++ b/src/services/environmentService.ts
@@ -46,11 +46,11 @@ export const createEnvironment = async (formData: FormDataCreateEnv) => {
   data.append("weeklySchedulesJson", JSON.stringify(formData.weeklySchedules));
   data.append(
     "discountPoliciesJson",
-    JSON.stringify(formData.discountPolicies),
+    JSON.stringify(formData.discountPolicies)
   );
   data.append(
     "servicePublicKeysJson",
-    JSON.stringify(formData.servicePublicKeys),
+    JSON.stringify(formData.servicePublicKeys)
   );
 
   try {
@@ -75,7 +75,7 @@ export const createEnvironment = async (formData: FormDataCreateEnv) => {
 export const fetchEnvironments = async (
   searchParams: URLSearchParams,
   page: number,
-  limit: number,
+  limit: number
 ) => {
   try {
     const areas: Area[] = [];
@@ -122,7 +122,7 @@ export const fetchEnvironments = async (
           "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
-      },
+      }
     );
 
     if (!res.ok) {
@@ -136,6 +136,63 @@ export const fetchEnvironments = async (
   }
 };
 
+export const fetchAvailableEquipment = async (
+  searchParams: URLSearchParams
+): Promise<{ name: string; count: number }[]> => {
+  const areas: Area[] = [];
+  searchParams.forEach((value, key) => {
+    if (key.startsWith("area_")) {
+      areas.push({
+        AreaPublicKey: key.replace("area_", ""),
+        MinQuantity: parseInt(value),
+      });
+    }
+  });
+
+  const services = searchParams.get("services")?.split(",") || [];
+
+  const requestBody = {
+    location: searchParams.get("city") || undefined,
+    environmentTypePublicKey: searchParams.get("type") || undefined,
+    startDate: searchParams.get("startDate")
+      ? Math.floor(new Date(searchParams.get("startDate")!).getTime() / 1000)
+      : undefined,
+    endDate: searchParams.get("endDate")
+      ? Math.floor(new Date(searchParams.get("endDate")!).getTime() / 1000)
+      : undefined,
+    servicePublicKeys: services,
+    areas,
+    instantBookingRequired:
+      searchParams.get("instantBooking") === "true" ? true : false,
+    minPrice: searchParams.get("minPrice")
+      ? parseFloat(searchParams.get("minPrice")!)
+      : undefined,
+    maxPrice: searchParams.get("maxPrice")
+      ? parseFloat(searchParams.get("maxPrice")!)
+      : 2000,
+    minCapacity: searchParams.get("minCapacity")
+      ? parseFloat(searchParams.get("minCapacity")!)
+      : 0,
+  };
+
+  const res = await fetch(
+    "http://localhost:5150/api/environments/available-equipment",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch available equipment");
+  }
+
+  return await res.json();
+}
+
 export const getOwnerEnvironments = async (page = 1, limit = 10) => {
   try {
     const res = await authFetch(
@@ -143,7 +200,7 @@ export const getOwnerEnvironments = async (page = 1, limit = 10) => {
       {
         method: "GET",
         credentials: "include",
-      },
+      }
     );
 
     if (!res.ok) {
@@ -161,7 +218,7 @@ export const getOwnerEnvironments = async (page = 1, limit = 10) => {
 export const getEnvironmentByPublicId = async (publicId: string) => {
   try {
     const res = await fetch(
-      `http://localhost:5150/api/environments/single?publicId=${publicId}`,
+      `http://localhost:5150/api/environments/single?publicId=${publicId}`
     );
 
     if (!res.ok) {

--- a/src/types/AllEnvironments.ts
+++ b/src/types/AllEnvironments.ts
@@ -29,4 +29,5 @@ export interface Environment {
   rentalUnit: string;
   photoUrls: string[];
   pricingPolicies: PricingPolicy[];
+  equipment: string;
 }


### PR DESCRIPTION
### What I did

Updated the frontend to support filtering and displaying environments based on detected equipment objects and their quantities.

---

### Why I did it

To allow users to:

* Filter environments using specific equipment (e.g. "Horno", "Microondas") and required minimum quantities.
* See which objects are available in each environment card, with emphasis on those matching their filter.

---

### How I did it

* Updated the `Environment` interface to include the `equipment` field (as a JSON string).
* Enhanced the `fetchEnvironments` service to extract `equipment_` values from `URLSearchParams` and include them in the `equipmentRequired` field for the backend.
* In `EnvironmentCard`, parsed the `equipment` field, matched it with the search filters, and displayed horizontal `Chip`s for each object:

  * Prioritized chips that match the user’s selected filters.
  * Ordered chips by relevance and quantity.
* Ensured fallback behavior when no filters are applied or `equipment` is missing.
