### PR TITLE
Feature/spacio 106/update owner bank payment data

### DIFF
--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,36 +1,7 @@
-"use client";
-import { useSelector } from "react-redux";
-import { RootState } from "@/store";
-import {
-  Box,
-  Typography,
-  Avatar,
-  Container,
-  Divider,
-  Chip,
-  Grid,
-  Paper,
-} from "@mui/material";
-import LoggedOutProfile from "@/components/profile/LoggedOutProfile";
-import EmailIcon from "@mui/icons-material/Email";
-import PhoneIcon from "@mui/icons-material/Phone";
-import VerifiedIcon from "@mui/icons-material/Verified";
-import { UserRole } from "@/types/Users";
-import LogoutButton from "@/components/buttons/LogOutButton";
+import ProfileClient from "@/components/client/ProfileClient";
+import { Container } from "@mui/material";
 
 export default function ProfilePage() {
-  const user = useSelector((state: RootState) => state.user);
-  const isLoggedIn = !!user?.publicId;
-
-  if (!isLoggedIn) {
-    return (
-      <LoggedOutProfile
-        imageSrc="/images/illustrations/profile.svg"
-        title="Accede para ver tu perfil"
-      />
-    );
-  }
-
   return (
     <Container
       maxWidth={false}
@@ -41,57 +12,7 @@ export default function ProfilePage() {
         justifyContent: "center",
       }}
     >
-      <Paper elevation={3} sx={{ p: 4, borderRadius: 4, mt: 4 }}>
-        <Box display="flex" flexDirection="column" alignItems="center" mb={4}>
-          <Avatar
-            src={user.photoFileUrl || undefined}
-            alt={user.name}
-            sx={{ width: 100, height: 100, mb: 2 }}
-          />
-          <Typography variant="h5" fontWeight="bold">
-            {user.name}
-          </Typography>
-          {user.role === UserRole.Admin && (
-            <Chip
-              icon={<VerifiedIcon />}
-              label="Administrador"
-              size="small"
-              sx={{ mt: 1 }}
-            />
-          )}
-        </Box>
-
-        <Divider sx={{ mb: 3 }} />
-
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 12 }}>
-            <Box display="flex" alignItems="center" gap={1}>
-              <EmailIcon fontSize="small" />
-              <Typography variant="body1">{user.email}</Typography>
-              {user.verifiedEmail && (
-                <Chip
-                  label="Email verificado"
-                  size="small"
-                  color="primary"
-                  variant="outlined"
-                />
-              )}
-            </Box>
-          </Grid>
-
-          <Grid size={{ xs: 12 }}>
-            <Box display="flex" alignItems="center" gap={1}>
-              <PhoneIcon fontSize="small" />
-              <Typography variant="body1">
-                {user.phone || "Sin número telefónico"}
-              </Typography>
-            </Box>
-          </Grid>
-        </Grid>
-      </Paper>
-      <Box display="flex" justifyContent="center" mt={2}>
-        <LogoutButton />
-      </Box>
+      <ProfileClient />
     </Container>
   );
 }

--- a/src/app/reservas/page.tsx
+++ b/src/app/reservas/page.tsx
@@ -53,7 +53,7 @@ const MyReservationsPage = () => {
         const { items, totalPages } = await getMyReservations(
           status,
           page,
-          limit
+          limit,
         );
         setReservations(items);
         setTotalPages(totalPages);

--- a/src/app/reservas/page.tsx
+++ b/src/app/reservas/page.tsx
@@ -17,6 +17,7 @@ import { getMyReservations } from "@/services/reservationService";
 import { ReservationResponse } from "@/types/Reservations";
 import { UserRole } from "@/types/Users";
 import ReservationList from "@/components/card/ReservationList";
+import { PageRoutes } from "@/utils/constants/page-routes";
 
 const MyReservationsPage = () => {
   const userRole = useSelector((state: RootState) => state.user.role);
@@ -36,13 +37,13 @@ const MyReservationsPage = () => {
     const newParams = new URLSearchParams(searchParams.toString());
     newParams.set("type", newValue);
     newParams.set("page", "1");
-    router.push(`/my-reservations?${newParams.toString()}`);
+    router.push(`${PageRoutes.Booking}?${newParams.toString()}`);
   };
 
   const handlePageChange = (_: React.ChangeEvent<unknown>, page: number) => {
     const newParams = new URLSearchParams(searchParams.toString());
     newParams.set("page", page.toString());
-    router.push(`/my-reservations?${newParams.toString()}`);
+    router.push(`${PageRoutes.Booking}?${newParams.toString()}`);
   };
 
   useEffect(() => {
@@ -52,7 +53,7 @@ const MyReservationsPage = () => {
         const { items, totalPages } = await getMyReservations(
           status,
           page,
-          limit,
+          limit
         );
         setReservations(items);
         setTotalPages(totalPages);

--- a/src/components/card/ReservationList.tsx
+++ b/src/components/card/ReservationList.tsx
@@ -12,6 +12,7 @@ import { type ReservationResponse } from "@/types/Reservations";
 import { useRouter } from "next/navigation";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import ReservationStatusChip from "../chip/ReservationStatusChip";
+import { ClockIcon } from "@mui/x-date-pickers";
 
 type Props = {
   reservations: ReservationResponse[];
@@ -82,9 +83,14 @@ const ReservationList: React.FC<Props> = ({ reservations }) => {
                         }
                       >
                         <Box width="100%" px={1}>
-                          <Typography variant="body2">
-                            ⏰ {rangeText} —{" "}
-                            <b>
+                          <Typography
+                            variant="body1"
+                            display={"flex"}
+                            alignItems={"center"}
+                          >
+                            <ClockIcon style={{ marginRight: 4 }} /> {rangeText}{" "}
+                            —{" "}
+                            <b style={{ marginLeft: 4 }}>
                               {res.currency} {res.totalPrice.toFixed(2)}
                             </b>
                           </Typography>

--- a/src/components/client/ProfileClient.tsx
+++ b/src/components/client/ProfileClient.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSelector } from "react-redux";
+import { RootState } from "@/store";
+import { Paper, Box } from "@mui/material";
+import LoggedOutProfile from "../profile/LoggedOutProfile";
+import ProfileDetails from "../profile/ProfileDetails";
+
+export default function ProfileClient() {
+  const user = useSelector((state: RootState) => state.user);
+  const isLoggedIn = !!user?.publicId;
+
+  if (!isLoggedIn) {
+    return (
+      <LoggedOutProfile
+        imageSrc="/images/illustrations/profile.svg"
+        title="Accede para ver tu perfil"
+      />
+    );
+  }
+
+  return (
+    <Paper elevation={3} sx={{ p: 4, borderRadius: 4, mt: 4 }}>
+      <ProfileDetails user={user} />
+    </Paper>
+  );
+}

--- a/src/components/client/ProfileClient.tsx
+++ b/src/components/client/ProfileClient.tsx
@@ -2,7 +2,7 @@
 
 import { useSelector } from "react-redux";
 import { RootState } from "@/store";
-import { Paper, Box } from "@mui/material";
+import { Paper } from "@mui/material";
 import LoggedOutProfile from "../profile/LoggedOutProfile";
 import ProfileDetails from "../profile/ProfileDetails";
 

--- a/src/components/modal/BankPaymentModal.tsx
+++ b/src/components/modal/BankPaymentModal.tsx
@@ -1,0 +1,59 @@
+"use client";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from "@mui/material";
+import { useState } from "react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function BankPaymentModal({ open, onClose }: Props) {
+  const [accountNumber, setAccountNumber] = useState("");
+  const [accountHolder, setAccountHolder] = useState("");
+  const [bankName, setBankName] = useState("");
+
+  const handleSubmit = async () => {
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Editar Datos Bancarios</DialogTitle>
+      <DialogContent
+        sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}
+      >
+        <TextField
+          label="Número de cuenta"
+          value={accountNumber}
+          onChange={(e) => setAccountNumber(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Titular de la cuenta"
+          value={accountHolder}
+          onChange={(e) => setAccountHolder(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Banco"
+          value={bankName}
+          onChange={(e) => setBankName(e.target.value)}
+          fullWidth
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button onClick={handleSubmit} variant="contained">
+          Guardar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/modal/BankPaymentModal.tsx
+++ b/src/components/modal/BankPaymentModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import {
   Dialog,
   DialogTitle,
@@ -8,24 +9,66 @@ import {
   Button,
 } from "@mui/material";
 import { useState } from "react";
+import {
+  createBankPayment,
+  updateBankPayment,
+} from "@/services/bankPaymentService";
+import { BankPaymentData } from "@/types/BankPaymentData";
 
 type Props = {
   open: boolean;
   onClose: () => void;
+  mode: "create" | "update";
+  defaultValues?: Partial<BankPaymentData>;
 };
 
-export default function BankPaymentModal({ open, onClose }: Props) {
-  const [accountNumber, setAccountNumber] = useState("");
-  const [accountHolder, setAccountHolder] = useState("");
-  const [bankName, setBankName] = useState("");
+export default function BankPaymentModal({
+  open,
+  onClose,
+  mode,
+  defaultValues,
+}: Props) {
+  const [accountNumber, setAccountNumber] = useState(
+    defaultValues?.bankAccountNumber || "",
+  );
+  const [accountHolder, setAccountHolder] = useState(
+    defaultValues?.bankAccountHolder || "",
+  );
+  const [bankName, setBankName] = useState(defaultValues?.bankName || "");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async () => {
-    onClose();
+    setLoading(true);
+    setError(null);
+    const payload: BankPaymentData = {
+      bankAccountNumber: accountNumber,
+      bankAccountHolder: accountHolder,
+      bankName,
+    };
+
+    try {
+      if (mode === "update") {
+        await updateBankPayment(payload);
+      } else {
+        await createBankPayment(payload);
+      }
+      onClose();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      setError(err.message || "Error inesperado");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Editar Datos Bancarios</DialogTitle>
+      <DialogTitle>
+        {mode === "update"
+          ? "Actualizar Datos Bancarios"
+          : "Agregar Datos Bancarios"}
+      </DialogTitle>
       <DialogContent
         sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}
       >
@@ -47,11 +90,22 @@ export default function BankPaymentModal({ open, onClose }: Props) {
           onChange={(e) => setBankName(e.target.value)}
           fullWidth
         />
+        {error && (
+          <p style={{ color: "red", fontSize: "0.9rem", marginTop: "4px" }}>
+            {error}
+          </p>
+        )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancelar</Button>
-        <Button onClick={handleSubmit} variant="contained">
-          Guardar
+        <Button onClick={onClose} disabled={loading}>
+          Cancelar
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={loading || !accountNumber || !accountHolder || !bankName}
+        >
+          {mode === "update" ? "Actualizar" : "Guardar"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/components/profile/ProfileDetails.tsx
+++ b/src/components/profile/ProfileDetails.tsx
@@ -1,0 +1,94 @@
+import {
+  Avatar,
+  Box,
+  Chip,
+  Divider,
+  Grid,
+  Typography,
+  Button,
+} from "@mui/material";
+import VerifiedIcon from "@mui/icons-material/Verified";
+import EmailIcon from "@mui/icons-material/Email";
+import PhoneIcon from "@mui/icons-material/Phone";
+import { UserRole, UserState as User } from "@/types/Users";
+import LogoutButton from "../buttons/LogOutButton";
+import { useState } from "react";
+import BankPaymentModal from "../modal/BankPaymentModal";
+
+type Props = {
+  user: User;
+};
+
+export default function ProfileDetails({ user }: Props) {
+  const [openModal, setOpenModal] = useState(false);
+
+  return (
+    <>
+      <Box display="flex" flexDirection="column" alignItems="center" mb={4}>
+        <Avatar
+          src={user.photoFileUrl || undefined}
+          alt={user.name}
+          sx={{ width: 100, height: 100, mb: 2 }}
+        />
+        <Typography variant="h5" fontWeight="bold">
+          {user.name}
+        </Typography>
+        {user.role === UserRole.Admin && (
+          <Chip
+            icon={<VerifiedIcon />}
+            label="Administrador"
+            size="small"
+            sx={{ mt: 1 }}
+          />
+        )}
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12 }}>
+          <Box display="flex" alignItems="center" gap={1}>
+            <EmailIcon fontSize="small" />
+            <Typography variant="body1">{user.email}</Typography>
+            {user.verifiedEmail && (
+              <Chip
+                label="Email verificado"
+                size="small"
+                color="primary"
+                variant="outlined"
+              />
+            )}
+          </Box>
+        </Grid>
+
+        <Grid size={{ xs: 12 }}>
+          <Box display="flex" alignItems="center" gap={1}>
+            <PhoneIcon fontSize="small" />
+            <Typography variant="body1">
+              {user.phone || "Sin número telefónico"}
+            </Typography>
+          </Box>
+        </Grid>
+
+        {user.role === UserRole.Owner && (
+          <Grid size={{ xs: 12 }} mt={2}>
+            <Button variant="outlined" onClick={() => setOpenModal(true)}>
+              Editar datos bancarios
+            </Button>
+          </Grid>
+        )}
+      </Grid>
+
+      <Box display="flex" justifyContent="center" mt={4}>
+        <LogoutButton />
+      </Box>
+
+      {user.role === UserRole.Owner && (
+        <BankPaymentModal
+          open={openModal}
+          onClose={() => setOpenModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/profile/ProfileDetails.tsx
+++ b/src/components/profile/ProfileDetails.tsx
@@ -87,6 +87,8 @@ export default function ProfileDetails({ user }: Props) {
         <BankPaymentModal
           open={openModal}
           onClose={() => setOpenModal(false)}
+          mode={user.bankPaymentData ? "update" : "create"}
+          defaultValues={user.bankPaymentData}
         />
       )}
     </>

--- a/src/hooks/DeleteMe.md
+++ b/src/hooks/DeleteMe.md
@@ -1,1 +1,0 @@
-Folder to contain custom hooks

--- a/src/services/bankPaymentService.ts
+++ b/src/services/bankPaymentService.ts
@@ -1,0 +1,31 @@
+import { BankPaymentData } from "@/types/BankPaymentData";
+
+export async function updateBankPayment(data: BankPaymentData): Promise<void> {
+  const response = await fetch("http://localhost:5123/api/bank-payment", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error("Error al actualizar los datos bancarios");
+  }
+}
+
+export async function createBankPayment(data: BankPaymentData): Promise<void> {
+  const response = await fetch("http://localhost:5123/api/bank-payment", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error("Error al guardar los datos bancarios");
+  }
+}

--- a/src/types/BankPaymentData.ts
+++ b/src/types/BankPaymentData.ts
@@ -1,0 +1,5 @@
+export type BankPaymentData = {
+  bankAccountNumber: string;
+  bankAccountHolder: string;
+  bankName: string;
+};

--- a/src/types/Users.ts
+++ b/src/types/Users.ts
@@ -1,3 +1,5 @@
+import { BankPaymentData } from "./BankPaymentData";
+
 export interface UserState {
   publicId?: string;
   name?: string;
@@ -12,6 +14,7 @@ export interface UserState {
   verified?: boolean;
   accessToken?: string;
   refreshToken?: string;
+  bankPaymentData?: BankPaymentData;
 }
 
 export enum UserRole {


### PR DESCRIPTION
#### What I did

* Added frontend support for owners to view and update their bank payment data from the profile page.
* Created a reusable modal component to handle both creation and update of bank information.
* Integrated the modal with Redux state and backend service functions (`POST` and `PUT`).
* Extended the `UserState` type in Redux to include `bankPaymentData`.

---

#### Why I did it

* To complete the frontend part of the "Update Owner’s Bank Payment Data" user story.
* To give owners a clear and secure interface for managing their payout account information.
* To ensure a consistent experience by using the current session and Redux for state tracking.

---

#### How I did it

* Refactored the `ProfilePage` to remove unnecessary `"use client"` and move interactivity to separate client components.
* Created `ProfileClient`, `ProfileDetails`, and `BankPaymentModal` components.
* Used conditional rendering to show the "Editar datos bancarios" button only for owners.
* Preloaded existing bank data from Redux and passed it to the modal as default values.
* Added service functions for `createBankPayment()` and `updateBankPayment()` and called the appropriate one based on modal mode.
* Handled user state loading via `fetchCurrentSession` and integrated `bankPaymentData` into Redux.
