### PR TITLE
Feature/spacio 107/become an owner

### DIFF
--- a/src/components/modal/BankPaymentModal.tsx
+++ b/src/components/modal/BankPaymentModal.tsx
@@ -7,6 +7,8 @@ import {
   DialogActions,
   TextField,
   Button,
+  Box,
+  Typography,
 } from "@mui/material";
 import { useState } from "react";
 import {
@@ -29,10 +31,10 @@ export default function BankPaymentModal({
   defaultValues,
 }: Props) {
   const [accountNumber, setAccountNumber] = useState(
-    defaultValues?.bankAccountNumber || "",
+    defaultValues?.bankAccountNumber || ""
   );
   const [accountHolder, setAccountHolder] = useState(
-    defaultValues?.bankAccountHolder || "",
+    defaultValues?.bankAccountHolder || ""
   );
   const [bankName, setBankName] = useState(defaultValues?.bankName || "");
   const [loading, setLoading] = useState(false);
@@ -64,6 +66,25 @@ export default function BankPaymentModal({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      {mode === "create" && (
+        <Box
+          sx={{
+            backgroundColor: "#f1f1f1",
+            borderRadius: 2,
+            padding: 2,
+            fontSize: "0.9rem",
+            color: "#444",
+          }}
+        >
+          <Typography fontWeight={500}>
+            Para convertirte en propietario y comenzar a publicar tus ambientes
+            en Spacio, por favor completa tus datos bancarios. Esta información
+            será utilizada para transferirte tus ingresos generados por las
+            reservas que recibas.
+          </Typography>
+        </Box>
+      )}
+
       <DialogTitle>
         {mode === "update"
           ? "Actualizar Datos Bancarios"

--- a/src/components/modal/BankPaymentModal.tsx
+++ b/src/components/modal/BankPaymentModal.tsx
@@ -31,10 +31,10 @@ export default function BankPaymentModal({
   defaultValues,
 }: Props) {
   const [accountNumber, setAccountNumber] = useState(
-    defaultValues?.bankAccountNumber || ""
+    defaultValues?.bankAccountNumber || "",
   );
   const [accountHolder, setAccountHolder] = useState(
-    defaultValues?.bankAccountHolder || ""
+    defaultValues?.bankAccountHolder || "",
   );
   const [bankName, setBankName] = useState(defaultValues?.bankName || "");
   const [loading, setLoading] = useState(false);

--- a/src/components/profile/ProfileDetails.tsx
+++ b/src/components/profile/ProfileDetails.tsx
@@ -110,7 +110,7 @@ export default function ProfileDetails({ user }: Props) {
       {user.role === UserRole.User && (
         <>
           <Box my={4}>
-            <RentPromptSection />
+            <RentPromptSection onClick={() => setOpenModal(true)} />
           </Box>
           <BankPaymentModal
             open={openModal}

--- a/src/components/profile/ProfileDetails.tsx
+++ b/src/components/profile/ProfileDetails.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 import BankPaymentModal from "../modal/BankPaymentModal";
 import { PageRoutes } from "@/utils/constants/page-routes";
 import Link from "next/link";
+import RentPromptSection from "@/sections/home/RentPromptSection";
 
 type Props = {
   user: User;
@@ -105,6 +106,18 @@ export default function ProfileDetails({ user }: Props) {
           mode={user.bankPaymentData ? "update" : "create"}
           defaultValues={user.bankPaymentData}
         />
+      )}
+      {user.role === UserRole.User && (
+        <>
+          <Box my={4}>
+            <RentPromptSection />
+          </Box>
+          <BankPaymentModal
+            open={openModal}
+            onClose={() => setOpenModal(false)}
+            mode="create"
+          />
+        </>
       )}
     </>
   );

--- a/src/sections/home/RentPromptSection.tsx
+++ b/src/sections/home/RentPromptSection.tsx
@@ -5,7 +5,7 @@ type RentPromptProps = {
   onClick?: () => void;
 };
 
-const RentPromptSection = ({ onClick = () => {} }: RentPromptProps) => {
+const RentPromptSection = ({ onClick }: RentPromptProps) => {
   return (
     <Box sx={{ backgroundColor: "#000", py: 4, px: 4, textAlign: "center" }}>
       <Typography

--- a/src/sections/home/RentPromptSection.tsx
+++ b/src/sections/home/RentPromptSection.tsx
@@ -1,16 +1,13 @@
 import { ColorPalette } from "@/utils/constants/ui-constants";
 import { Box, Button, Typography } from "@mui/material";
 
-const RentPromptSection = () => {
+type RentPromptProps = {
+  onClick?: () => void;
+};
+
+const RentPromptSection = ({ onClick = () => {} }: RentPromptProps) => {
   return (
-    <Box
-      sx={{
-        backgroundColor: "#000",
-        py: 4,
-        px: 4,
-        textAlign: "center",
-      }}
-    >
+    <Box sx={{ backgroundColor: "#000", py: 4, px: 4, textAlign: "center" }}>
       <Typography
         variant="h6"
         gutterBottom
@@ -27,6 +24,7 @@ const RentPromptSection = () => {
         alquilarla.
       </Typography>
       <Button
+        onClick={onClick}
         variant="contained"
         sx={{
           mt: 2,


### PR DESCRIPTION
**What I did:**

* Updated the profile page to allow regular users (`User` role) to become owners by registering their bank account.
* Displayed a promotional banner encouraging users to publish their space.
* Added a conditional flow that shows a modal form to submit bank payment information when clicking the banner.
* Included instructional text (in Spanish) inside the modal for new owners.
* Triggered page refresh and navigation to “My Environments” after successful bank data submission.

---

**Why I did it:**

* Users must submit valid bank account information to receive payments and gain `Owner` status.
* This is the first step toward enabling users to publish rentable spaces on the platform.
* Ensures only verified owners can access owner-specific features.

---

**How I did it:**

* Reused and extended the `BankPaymentModal` to support both creation and update flows.
* Connected the modal to the banner in `RentPromptSection` using a callback prop.
* Used `router.refresh()` and `router.push("/my-environments")` to update the session and navigate after creating the bank info.
* Displayed role-specific content based on the current user's role (`User`, `Owner`, or `Admin`).
